### PR TITLE
feat: load after directory for custom plugins

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -214,6 +214,9 @@ lib.makeOverridable (
         luaEnv = neovim.lua.withPackages extraLuaPackages;
         inherit (neovim.lua.pkgs.luaLib) genLuaPathAbsStr genLuaCPathAbsStr;
         paths = lib.concatStringsSep "," ([ builtConfigDir ] ++ lib.optionals dev devPluginPaths);
+
+        devAfterPaths = lib.concatStringsSep "," (map (p: p+"/after") devPluginPaths);
+        devAfterRtp = lib.optionalString dev " | set rtp+=${devAfterPaths}";
       in
       [
         "--prefix"
@@ -236,7 +239,7 @@ lib.makeOverridable (
         appName
 
         "--add-flags"
-        "--cmd 'set packpath^=${paths} | set rtp^=${paths}'"
+        "--cmd 'set packpath^=${paths} | set rtp^=${paths} ${devAfterRtp}'"
 
         "--add-flags"
         "-u '${builtConfigDir}/init.lua'"


### PR DESCRIPTION
I was trying to add some `after/ftplugin` files and they weren't loading at all. I'm not 100% but I think `after/` has to be manually added to the rtp at the end. When I look at the default rtp set by nvim it has a bunch of `/after` ones tacked on the end in common spots, so that's why I think think it has to be done manually.
