### PR TITLE
Prepend plugins to rtp

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -124,8 +124,8 @@ lib.makeOverridable (
         vim.env.PATH =  vim.env.PATH .. ":${lib.makeBinPath ([ providers ] ++ extraBinPath)}"
         package.path = "${luaLib.genLuaPathAbsStr luaEnv};$LUA_PATH" .. package.path
         package.cpath = "${luaLib.genLuaCPathAbsStr luaEnv};$LUA_CPATH" .. package.cpath
-        vim.opt.packpath:append('$out')
-        vim.opt.runtimepath:append('$out')
+        vim.opt.packpath:prepend('$out')
+        vim.opt.runtimepath:prepend('$out')
         ${devRtp}
         ${providerLua}
         ${sourceLua}


### PR DESCRIPTION
some plugins (e.g. vimtex) rely on being before nvim builtins in rtp e.g. [vimtex](https://github.com/NotAShelf/nvf/issues/566)

This goes for treesitter query files as well:

TS queries are searched in order of rtp, and stops at the first found query file (that doesn't use
the `inherits` modeline), meaning neovim's builtin queries are favored over plugin ones, which is
usually not the desired outcome.
