### PR TITLE
Render readme as a documentation page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,17 +12,18 @@ export default defineConfig({
       // { text: 'Options', link: '/options' }
     ],
 
-    // sidebar: [
-    //   {
-    //     // text: 'Examples',
-    //     items: [
-    //       { text: 'Options', link: '/options' },
-    //     ]
-    //   }
-    // ],
+    sidebar: [
+      {
+        // text: 'Examples',
+        items: [
+          { text: 'Documentation', link: '/documentation' },
+          { text: 'Options', link: '/options' },
+        ]
+      }
+    ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/vuejs/vitepress' }
+      { icon: 'github', link: 'https://github.com/Gerg-L/mnw' }
     ],
 
     outline: {

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,5 @@
+---
+title: Documentation
+---
+
+<!--@include: ../README.md -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ hero:
     - theme: brand
       text: Options
       link: /options
+    - theme: brand
+      text: Documentation
+      link: /documentation
     - theme: alt
       text: GitHub
       link: https://github.com/Gerg-L/mnw


### PR DESCRIPTION
Quick documentation follow-up.

This will render the README.md as a page at https://gerg-l.github.io/mnw/documentation.html