### PR TITLE
fix: prepend plugins to runtimepath

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -225,11 +225,11 @@ lib.makeOverridable (
           "--cmd \"lua "
           + lib.concatStringsSep ";" (
             [
-              "vim.opt.packpath:append('${builtConfigDir}')"
-              "vim.opt.runtimepath:append('${builtConfigDir}')"
+              "vim.opt.packpath:prepend('${builtConfigDir}')"
+              "vim.opt.runtimepath:prepend('${builtConfigDir}')"
             ]
             ++ (lib.optionals (dev && devPlugins != [ ]) [
-              "vim.opt.runtimepath:append('${lib.concatStringsSep "," devPlugins}')"
+              "vim.opt.runtimepath:prepend('${lib.concatStringsSep "," devPlugins}')"
               "vim.opt.runtimepath:append('${lib.concatMapStringsSep "," (p: "${p}/after") devPlugins}')"
             ])
             ++ (lib.mapAttrsToList


### PR DESCRIPTION
sorry, I was waiting for confirmation on whether the previous PR worked but never got a response,
and so I forgot about its existence. But now I got a
[confirmation](https://github.com/NotAShelf/nvf/issues/566#issuecomment-2848815478)


many plugins expect to be placed before neovim runtime in rtp, for the
purpose of overriding and preventing conflicting behaviours, e.g. vimtex
uses b:did_ftplugin to ensure only one ftplugin is loaded (and vimtex is
only loaded when it comes before neovim runtime in rtp)
