### PR TITLE
fix(npinsToPlugins): ensure derivations are recognized as vim plugins

### DIFF
--- a/npinsToPlugins.nix
+++ b/npinsToPlugins.nix
@@ -106,6 +106,7 @@ lib.mapAttrsToList
       name = "${name}-${version}";
       pname = name;
       inherit version;
+      vimPlugin = true;
       outPath = (mayOverride (func spec)).overrideAttrs {
         pname = name;
         name = "${name}-${version}";


### PR DESCRIPTION
Fixes my issue with [mrcjkb/nix-gen-luarc-json](https://github.com/mrcjkb/nix-gen-luarc-json).

This attribute is used to differentiate luaPackages that are also vimPlugins in nixpkgs ([source](https://github.com/NixOS/nixpkgs/blob/49fdabf6699517a41db58e09cefa6bf6ef53226b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix#L514)).