### PR TITLE
fix: resolve failure when parser folder contains only .dotfiles

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -186,7 +186,9 @@ lib.makeOverridable (
             fi
 
             if [[ -e "$source/parser" && -n "$(ls -A "$source/parser")" ]]; then
-              ln -nsf "$source/parser/"* -t "$out/parser"
+              for f in "$sources/parser/"* ; do 
+                ln -nsf "$f" -t "$out/parser"
+              done
             fi
 
             if [[ -e "$source/doc" && ! -e "$out/$path/doc" ]]; then


### PR DESCRIPTION
If a plugin contains a parser folder which only contains .dotfiles then the wrapper fails to build as it tries to link an empty source into "$out/parser". An example plugin which causes this issue is [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/tree/master/parser).

Resolves: #33