### PR TITLE
feat(docs): move examples to their own page

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,30 @@
+---
+title: Examples
+---
+# {{ $frontmatter.title }}
+
+## Official examples
+
+[Simple NixOS example](https://github.com/Gerg-L/mnw/tree/master/examples/nixos)
+
+[Standalone, easy development](https://github.com/Gerg-L/mnw/tree/master/examples/standalone)
+
+[Lazy loading with lazy.nvim](https://github.com/Gerg-L/mnw/tree/master/examples/lazy)
+
+[Lazy loading with lz.n](https://github.com/Gerg-L/mnw/tree/master/examples/lz.n)
+
+## Community examples
+
+[My Neovim flake](https://github.com/Gerg-L/nvim-flake)
+
+[nvf](https://github.com/NotAShelf/nvf)
+
+[viperML](https://github.com/viperML/dotfiles/blob/master/packages/neovim)
+
+[llakala](https://github.com/llakala/meovim)
+
+[adamcstephens](https://codeberg.org/adamcstephens/dotfiles/src/branch/main/apps/neovim)
+
+[HeitorAugustoLN](https://github.com/HeitorAugustoLN/nvim-config)
+
+Make a PR to add your config :D

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ hero:
     - theme: brand
       text: Options
       link: /options
+    - theme: brand
+      text: Examples
+      link: /examples
     - theme: alt
       text: GitHub
       link: https://github.com/Gerg-L/mnw

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,27 +100,3 @@ Currently mnw only has one lua global variable set
 Which is the path to the generated config directory of mnw
 
 You can build/view this directory by building the `.configDir` of the mnw package
-
-### Examples
-
-[Simple NixOS example](https://github.com/Gerg-L/mnw/tree/master/examples/nixos)
-
-[Standalone, easy development](https://github.com/Gerg-L/mnw/tree/master/examples/standalone)
-
-[Lazy loading with lazy.nvim](https://github.com/Gerg-L/mnw/tree/master/examples/lazy)
-
-[Lazy loading with lz.n](https://github.com/Gerg-L/mnw/tree/master/examples/lz.n)
-
-[My Neovim flake](https://github.com/Gerg-L/nvim-flake)
-
-[nvf](https://github.com/NotAShelf/nvf)
-
-[viperML](https://github.com/viperML/dotfiles/blob/master/packages/neovim)
-
-[llakala](https://github.com/llakala/meovim)
-
-[adamcstephens](https://codeberg.org/adamcstephens/dotfiles/src/branch/main/apps/neovim)
-
-[HeitorAugustoLN](https://github.com/HeitorAugustoLN/nvim-config)
-
-Make a PR to add your config :D


### PR DESCRIPTION
When I tell people to use mnw, I want to show the examples to prove it's actually simple to use, but they're hidden away on the Usage page. This PR splits them out to their own page, for better discoverability.

Build the `docs` output locally, and can guarantee that at least the generated HTML is correct - but not sure how to actually view the docs after building. I _think_ everything is there for this to work, though.