### PR TITLE
fix: typo in custom fetchFromGitHub plugin example

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -84,7 +84,7 @@ Any plugin in `opt` will override the plugin of the same name in `start` when pr
         src = pkgs.fetchFromGitHub {
           owner = "";
           repo = "";
-          ref = "";
+          rev = "";
           hash = "";
         };
 


### PR DESCRIPTION
Fix: `pkgs.fetchFromGithub` expects `rev`, not `ref`

[Source](https://nixos.org/manual/nixpkgs/stable/#fetchfromgithub)