### PR TITLE
feat(wrapper): centralize treesitter queries like parsers

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -130,6 +130,7 @@ lib.makeOverridable (
             "+quit!"
 
           mkdir -p "$out/parser"
+          mkdir -p "$out/queries"
 
           shopt -s extglob
           for ((i = 0; i < "''${#pathsArray[@]}"; i++ ))
@@ -139,13 +140,17 @@ lib.makeOverridable (
 
             mkdir -p "$out/$path"
 
-            tolink=("$source/"!(doc|parser))
+            tolink=("$source/"!(doc|parser|queries))
             if (( ''${#tolink} )); then
               ln -ns "''${tolink[@]}"  -t "$out/$path"
             fi
 
             if [[ -e "$source/parser" && -n "$(ls "$source/parser")" ]]; then
               ln -nsf "$source/parser/"* -t "$out/parser"
+            fi
+
+            if [[ -e "$source/queries" && -n "$(ls "$source/queries")" ]]; then
+              ln -nsf "$source/queries/"* -t "$out/queries"
             fi
 
             if [[ -e "$source/doc" && ! -e "$out/$path/doc" ]]; then


### PR DESCRIPTION
After [NixOS/nixpkgs#470833](https://redirect.github.com/NixOS/nixpkgs/pull/470883), nvim-treesitter has separate derivations for queries (because it is not available in the runtimepath by default anymore), if using `withPlugins` it is currently symlinked with the parsers, but soon this will be done in the nixpkgs wrapper, so doing the same here, similarly to parsers, so it won't bloat the `runtimepath`