### PR TITLE
Revert "feat(wrapper): centralize treesitter queries like parsers"

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -130,7 +130,6 @@ lib.makeOverridable (
             "+quit!"
 
           mkdir -p "$out/parser"
-          mkdir -p "$out/queries"
 
           shopt -s extglob
           for ((i = 0; i < "''${#pathsArray[@]}"; i++ ))
@@ -140,17 +139,13 @@ lib.makeOverridable (
 
             mkdir -p "$out/$path"
 
-            tolink=("$source/"!(doc|parser|queries))
+            tolink=("$source/"!(doc|parser))
             if (( ''${#tolink} )); then
               ln -ns "''${tolink[@]}"  -t "$out/$path"
             fi
 
             if [[ -e "$source/parser" && -n "$(ls "$source/parser")" ]]; then
               ln -nsf "$source/parser/"* -t "$out/parser"
-            fi
-
-            if [[ -e "$source/queries" && -n "$(ls "$source/queries")" ]]; then
-              ln -nsf "$source/queries/"* -t "$out/queries"
             fi
 
             if [[ -e "$source/doc" && ! -e "$out/$path/doc" ]]; then


### PR DESCRIPTION
See https://github.com/Gerg-L/mnw/pull/47#issuecomment-3764270958. We can merge a working version in the future, but preventing a regression in the short term is preferred.