### PR TITLE
fix: don't recopy paths to store

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -33,9 +33,9 @@ lib.makeOverridable (
     pluginsToListOfStrings = lib.mapAttrsToList (
       n: v:
       if lib.isStringLike v then
-        "${v}"
+        toString v
       else if v ? src && lib.isStringLike v.src then
-        "${v.src}"
+        toString v.src
       else
         throw "mnw: plugin '${n}' cannot be coerced to string, ensure it has a 'outPath' or 'src'"
     );
@@ -76,10 +76,10 @@ lib.makeOverridable (
         luaEnv = neovim.lua.withPackages extraLuaPackages;
         inherit (neovim.lua.pkgs) luaLib;
 
-        sourceLua = lib.concatMapStringsSep "\n" (x: "dofile('${x}')") (
+        sourceLua = lib.concatMapStringsSep "\n" (x: "dofile('${toString x}')") (
           (lib.optional (initLua != "") (writeText "init.lua" initLua)) ++ luaFiles
         );
-        sourceVimL = lib.concatMapStringsSep "\n" (x: "vim.cmd('source ${x}')") (
+        sourceVimL = lib.concatMapStringsSep "\n" (x: "vim.cmd('source ${toString x}')") (
           (lib.optional (initViml != "") (writeText "init.vim" initViml)) ++ vimlFiles
         );
       in


### PR DESCRIPTION
We already have the assertion through module typechecks that any paths that make it this far are in the store. By using toString instead of a string interpolation, we avoid recopying the paths to the store.

Before this PR, I was getting this in my logs:
```
copying '/nix/store/s6wn8zhpg7znk764nad7lf4s8yf4nw4y-source/nvim' to the store...
copied source '/nix/store/s6wn8zhpg7znk764nad7lf4s8yf4nw4y-source/nvim' -> '/nix/store/q03qim90v7fwllrmhk4rgx7msyni6vl4-nvim'
```
After, it's gone!