### PR TITLE
docs: add codevogel/nestvim configuration example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,4 +28,6 @@ title: Examples
 
 [HeitorAugustoLN](https://github.com/HeitorAugustoLN/nvim-config)
 
+[codevogel's nestvim (standalone, lz.n)](https://github.com/codevogel/nestvim)
+
 Make a PR to add your config :D


### PR DESCRIPTION
I recently migrated to a standalone nix flake backed with `mnw` and `lz.n`.

Added some comments here and there to help newbies out (and also remind myself for the future). 

Might be of use to some!

Feel free to change the markdown text to just `nestvim` (or let me know and I'll do that before merging).