### PR TITLE
fix: make `NVIM_APPNAME` overridable

### DIFF
--- a/wrapper.nix
+++ b/wrapper.nix
@@ -256,7 +256,7 @@ lib.makeOverridable (
         )
         "--set"
         "NVIM_APPNAME"
-        appName
+        "''${NVIM_APPNAME:-${appName}}"
 
         "--set"
         "VIMINIT"


### PR DESCRIPTION
User calling `nvim` want to override `NVIM_APPNAME` sometimes to isolate debugging for different instances. 

Also: This change makes it possible also with `nvf` to wrap into own wrappers which still can set this variable and it is honored.